### PR TITLE
Fix nested GPT booting

### DIFF
--- a/scripts/brunch-init
+++ b/scripts/brunch-init
@@ -59,7 +59,10 @@ if [ -e "$img_part" ] && [ ! -z "$img_path" ]; then
 	else
 		echo "brunch: ChromeOS loopfile $img_path not found on device $img_part..." > /dev/kmsg
 	fi
-elif [ -e "$img_part" ]; then
+elif [ ! -z "$part_uuid" ]; then
+	img_part=$(blkid --match-token PARTUUID=$part_uuid | cut -d':' -f1)
+	mknod -m660 /dev/sdz b 7 4096
+	losetup -P /dev/sdz $img_part
 	echo "brunch: Trying to boot in nested GPT mode on device $img_part..." > /dev/kmsg
 	losetup -P /dev/sdz "$img_part"
 	bootdevice=/dev/sdz


### PR DESCRIPTION
This just fixes nested GPT booting
very basic tutorial (this assumes you already have a fully functioning copy of grub installed):
1. create an empty partition that is 16gb or larger. this is the partition where chrome os and all your data will be stored. this can be made with fdisk or gparted. you dont need to format it or anything, just make note of the path to the partition (it'll be something like /dev/sdaX or /dev/nvme0n1pX, where X is the partition number)
2. get the partition uuid using `sudo blkid <path to device from previous step>` make sure you get PARTUUID and not PTUUID
2. run this command `sudo losetup --show -fP <path to device from step 1>` and make note of the /dev/loop device
3. run `sudo chromeos-install.sh -src <chrome os recovery image>  -dst /dev/loopY` where Y is the device from the previous step.
4. create the following menu entries in your grub config using whichever method you like (i prefer grub customizer). make sure you change gpt_uuid in both 

name: Chrome OS
script:
```
search --no-floppy --fs-uuid --set=root 2044-6AA2
regexp --set disk "(^.+)(,gpt)" $root
gpt_uuid=<gpt uuid from step 2>
source /efi/boot/theme.cfg
source /efi/boot/settings.cfg

linux ($disk,7)$kernel boot=local noresume noswap loglevel=7 options=$options chromeos_bootsplash=$chromeos_bootsplash $cmdline_params \
	cros_secure cros_debug part_uuid=$gpt_uuid \
	console= vt.global_cursor_default=0 brunch_bootsplash=$brunch_bootsplash quiet

initrd ($disk,7)/lib/firmware/amd-ucode.img ($disk,7)/lib/firmware/intel-ucode.img ($disk,7)/initramfs.img
```

name: Chrome OS (Settings)
script:
```
search --no-floppy --fs-uuid --set=root 2044-6AA2
regexp --set disk "(^.+)(,gpt)" $root
gpt_uuid=<gpt uuid from step 2>
source /efi/boot/theme.cfg
source /efi/boot/settings.cfg

linux ($disk,7)/kernel boot=local noresume noswap loglevel=7 cros_secure cros_debug options= chromeos_bootsplash= part_uuid=$gpt_uuid edit_brunch_config=1
initrd ($disk,7)/lib/firmware/amd-ucode.img ($disk,7)/lib/firmware/intel-ucode.img ($disk,7)/initramfs.img
```

This is all based off some work that's already been done here: https://github.com/sebanc/brunch/issues/1211