### PR TITLE
Update device lists of ACPI keyboard IRQ override

### DIFF
--- a/kernel-patches/6.6/others/acpi_override_kbd_irq.patch
+++ b/kernel-patches/6.6/others/acpi_override_kbd_irq.patch
@@ -1,0 +1,278 @@
+diff --git a/drivers/acpi/resource.c b/drivers/acpi/resource.c
+index 85ae394..59423fe 100644
+--- a/drivers/acpi/resource.c
++++ b/drivers/acpi/resource.c
+@@ -385,62 +385,63 @@ unsigned int acpi_dev_get_irq_type(int triggering, int polarity)
+ }
+ EXPORT_SYMBOL_GPL(acpi_dev_get_irq_type);
+ 
+-static const struct dmi_system_id medion_laptop[] = {
++/*
++ * DMI matches for boards where the DSDT specifies the kbd IRQ as
++ * level active-low and using the override changes this to rising edge,
++ * stopping the keyboard from working.
++ */
++static const struct dmi_system_id irq1_level_low_skip_override[] = {
+ 	{
+-		.ident = "MEDION P15651",
++		/* MEDION P15651 */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "MEDION"),
+ 			DMI_MATCH(DMI_BOARD_NAME, "M15T"),
+ 		},
+ 	},
+ 	{
+-		.ident = "MEDION S17405",
++		/* MEDION S17405 */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "MEDION"),
+ 			DMI_MATCH(DMI_BOARD_NAME, "M17T"),
+ 		},
+ 	},
+ 	{
+-		.ident = "MEDION S17413",
++		/* MEDION S17413 */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "MEDION"),
+ 			DMI_MATCH(DMI_BOARD_NAME, "M1xA"),
+ 		},
+ 	},
+-	{ }
+-};
+-
+-static const struct dmi_system_id asus_laptop[] = {
+ 	{
+-		.ident = "Asus Vivobook K3402ZA",
++		/* Asus Vivobook K3402ZA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "K3402ZA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus Vivobook K3502ZA",
++		/* Asus Vivobook K3502ZA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "K3502ZA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus Vivobook S5402ZA",
++		/* Asus Vivobook S5402ZA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "S5402ZA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus Vivobook S5602ZA",
++		/* Asus Vivobook S5602ZA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "S5602ZA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus ExpertBook B1402CBA",
++		/* Asus ExpertBook B1402CBA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "B1402CBA"),
+@@ -454,53 +455,89 @@ static const struct dmi_system_id asus_laptop[] = {
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus ExpertBook B1502CBA",
++		/* Asus ExpertBook B1502CBA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "B1502CBA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus ExpertBook B2402CBA",
++		/* Asus ExpertBook B1502CGA */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_BOARD_NAME, "B1502CGA"),
++		},
++	},
++        {
++                /* Asus ExpertBook B1502CVA */
++                .matches = {
++                        DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++                        DMI_MATCH(DMI_BOARD_NAME, "B1502CVA"),
++                },
++        },
++	{
++		/* Asus ExpertBook B2402CBA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "B2402CBA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus ExpertBook B2402FBA",
++		/* Asus ExpertBook B2402FBA */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "B2402FBA"),
+ 		},
+ 	},
+ 	{
+-		.ident = "Asus ExpertBook B2502",
++		/* Asus ExpertBook B2502 */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_BOARD_NAME, "B2502CBA"),
+ 		},
+ 	},
+-	{ }
+-};
+-
+-static const struct dmi_system_id tongfang_gm_rg[] = {
+ 	{
+-		.ident = "TongFang GMxRGxx/XMG CORE 15 (M22)/TUXEDO Stellaris 15 Gen4 AMD",
++		/* Asus ExpertBook B2502FBA */
+ 		.matches = {
+-			DMI_MATCH(DMI_BOARD_NAME, "GMxRGxx"),
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_BOARD_NAME, "B2502FBA"),
++		},
++	},
++	{
++		/* Asus Vivobook E1504GA */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_BOARD_NAME, "E1504GA"),
++		},
++	},
++	{
++		/* Asus Vivobook E1504GAB */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_BOARD_NAME, "E1504GAB"),
++		},
++	},
++	{
++		/* LG Electronics 17U70P */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "LG Electronics"),
++			DMI_MATCH(DMI_BOARD_NAME, "17U70P"),
+ 		},
+ 	},
+ 	{ }
+ };
+ 
+-static const struct dmi_system_id maingear_laptop[] = {
++/*
++ * DMI matches for AMD Zen boards where the DSDT specifies the kbd IRQ
++ * as falling edge and this must be overridden to rising edge,
++ * to have a working keyboard.
++ */
++static const struct dmi_system_id irq1_edge_low_force_override[] = {
+ 	{
+-		.ident = "MAINGEAR Vector Pro 2 15",
++		/* TongFang GMxRGxx/XMG CORE 15 (M22)/TUXEDO Stellaris 15 Gen4 AMD */
+ 		.matches = {
+-			DMI_MATCH(DMI_SYS_VENDOR, "Micro Electronics Inc"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "MG-VCP2-15A3070T"),
+-		}
++			DMI_MATCH(DMI_BOARD_NAME, "GMxRGxx"),
++		},
+ 	},
+ 	{
+ 		/* TongFang GMxXGxx/TUXEDO Polaris 15 Gen5 AMD */
+@@ -522,16 +559,19 @@ static const struct dmi_system_id maingear_laptop[] = {
+ 		},
+ 	},
+ 	{
+-		.ident = "MAINGEAR Vector Pro 2 17",
++		/* MAINGEAR Vector Pro 2 15 */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Micro Electronics Inc"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "MG-VCP2-15A3070T"),
++		}
++	},
++	{
++		/* MAINGEAR Vector Pro 2 17 */
+ 		.matches = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "Micro Electronics Inc"),
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "MG-VCP2-17A3070T"),
+ 		},
+ 	},
+-	{ }
+-};
+-
+-static const struct dmi_system_id pcspecialist_laptop[] = {
+ 	{
+ 		/* TongFang GM6BGEQ / PCSpecialist Elimina Pro 16 M, RTX 3050 */
+ 		.matches = {
+@@ -550,15 +590,44 @@ static const struct dmi_system_id pcspecialist_laptop[] = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "GM6BG0Q"),
+ 		},
+ 	},
+-	{ }
+-};
+-
+-static const struct dmi_system_id lg_laptop[] = {
+ 	{
+-		.ident = "LG Electronics 17U70P",
++		/* Infinity E15-5A165-BM */
+ 		.matches = {
+-			DMI_MATCH(DMI_SYS_VENDOR, "LG Electronics"),
+-			DMI_MATCH(DMI_BOARD_NAME, "17U70P"),
++			DMI_MATCH(DMI_BOARD_NAME, "GM5RG1E0009COM"),
++		},
++	},
++	{
++		/* Infinity E15-5A305-1M */
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "GM5RGEE0016COM"),
++		},
++	},
++	{
++		/* Lunnen Ground 15 / AMD Ryzen 5 5500U */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Lunnen"),
++			DMI_MATCH(DMI_BOARD_NAME, "LLL5DAW"),
++		},
++	},
++	{
++		/* Lunnen Ground 16 / AMD Ryzen 7 5800U */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "Lunnen"),
++			DMI_MATCH(DMI_BOARD_NAME, "LL6FA"),
++		},
++	},
++	{
++		/* MAIBENBEN X577 */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "MAIBENBEN"),
++			DMI_MATCH(DMI_BOARD_NAME, "X577"),
++		},
++	},
++	{
++		/* Maibenben X565 */
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "MAIBENBEN"),
++			DMI_MATCH(DMI_BOARD_NAME, "X565"),
+ 		},
+ 	},
+ 	{ }
+@@ -574,12 +643,8 @@ struct irq_override_cmp {
+ };
+ 
+ static const struct irq_override_cmp override_table[] = {
+-	{ medion_laptop, 1, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_LOW, 0, false },
+-	{ asus_laptop, 1, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_LOW, 0, false },
+-	{ tongfang_gm_rg, 1, ACPI_EDGE_SENSITIVE, ACPI_ACTIVE_LOW, 1, true },
+-	{ maingear_laptop, 1, ACPI_EDGE_SENSITIVE, ACPI_ACTIVE_LOW, 1, true },
+-	{ pcspecialist_laptop, 1, ACPI_EDGE_SENSITIVE, ACPI_ACTIVE_LOW, 1, true },
+-	{ lg_laptop, 1, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_LOW, 0, false },
++	{ irq1_level_low_skip_override, 1, ACPI_LEVEL_SENSITIVE, ACPI_ACTIVE_LOW, 0, false },
++	{ irq1_edge_low_force_override, 1, ACPI_EDGE_SENSITIVE, ACPI_ACTIVE_LOW, 1, true },
+ };
+ 
+ static bool acpi_dev_irq_override(u32 gsi, u8 triggering, u8 polarity,


### PR DESCRIPTION
DSDT tables of certain laptops are mistakenly written, which causes the frozen keyboard issue. Thus, the Linux kernel maintains a list of devices with incorrect DSDT tables and overrides the configuration of keyboard IRQs. 

Although Linux 6.6 is very new, this list still has been updated since then. Thus, this patch is a backport from [the latest source code](https://github.com/torvalds/linux/blob/master/drivers/acpi/resource.c) (probably Linux 6.9) to fix some recent laptops.

I have tested this patch on my laptop (Asus Vivobook E1504GA) and confirmed it is working.