### PR TITLE
drm/amdgpu: enable redirection of irq's for IH V6.1

### DIFF
--- a/kernel-patches/6.6/others/steamdeck-ih-irq-redirection.patch
+++ b/kernel-patches/6.6/others/steamdeck-ih-irq-redirection.patch
@@ -1,0 +1,42 @@
+commit 413d3034f7cd55447aa75802928b74cbb2bac5e6
+Author: Sunil Khatri <sunil.khatri@amd.com>
+Date:   Fri Apr 12 15:05:00 2024 +0530
+
+    drm/amdgpu: enable redirection of irq's for IH V6.1
+    
+    Enable redirection of irq for pagefaults for specific
+    clients to avoid overflow without dropping interrupts.
+    
+    So here we redirect the interrupts to another IH ring
+    i.e ring1 where only these interrupts are processed.
+    
+    Signed-off-by: Sunil Khatri <sunil.khatri@amd.com>
+    Reviewed-by: Christian König <christian.koenig@amd.com>
+    Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+
+diff --git a/drivers/gpu/drm/amd/amdgpu/ih_v6_1.c b/drivers/gpu/drm/amd/amdgpu/ih_v6_1.c
+index b8da0fc29378..1d9490ba99d1 100644
+--- a/drivers/gpu/drm/amd/amdgpu/ih_v6_1.c
++++ b/drivers/gpu/drm/amd/amdgpu/ih_v6_1.c
+@@ -346,6 +346,21 @@ static int ih_v6_1_irq_init(struct amdgpu_device *adev)
+ 			    DELAY, 3);
+ 	WREG32_SOC15(OSSSYS, 0, regIH_MSI_STORM_CTRL, tmp);
+ 
++	/* Redirect the interrupts to IH RB1 for dGPU */
++	if (adev->irq.ih1.ring_size) {
++		tmp = RREG32_SOC15(OSSSYS, 0, regIH_RING1_CLIENT_CFG_INDEX);
++		tmp = REG_SET_FIELD(tmp, IH_RING1_CLIENT_CFG_INDEX, INDEX, 0);
++		WREG32_SOC15(OSSSYS, 0, regIH_RING1_CLIENT_CFG_INDEX, tmp);
++
++		tmp = RREG32_SOC15(OSSSYS, 0, regIH_RING1_CLIENT_CFG_DATA);
++		tmp = REG_SET_FIELD(tmp, IH_RING1_CLIENT_CFG_DATA, CLIENT_ID, 0xa);
++		tmp = REG_SET_FIELD(tmp, IH_RING1_CLIENT_CFG_DATA, SOURCE_ID, 0x0);
++		tmp = REG_SET_FIELD(tmp, IH_RING1_CLIENT_CFG_DATA,
++				    SOURCE_ID_MATCH_ENABLE, 0x1);
++
++		WREG32_SOC15(OSSSYS, 0, regIH_RING1_CLIENT_CFG_DATA, tmp);
++	}
++
+ 	pci_set_master(adev->pdev);
+ 
+ 	/* enable interrupts */


### PR DESCRIPTION
xHCI driver knows about it and make sure to permit wakeup only at the appropriate time.

For host mode, if the controller goes through the dwc3 code path, then a child xHCI platform device is created. Make sure the platform device also inherits the wakeup setting for xHCI to enable remote wakeup.

For device mode, make sure to disable system wakeup if no gadget driver is bound. We may experience unwanted system wakeup due to the wakeup signal from the controller PMU detecting connection/disconnection when in low power (D3). E.g. In the case of Steam Deck, the PCI PME prevents the system staying in suspend.