### PR TITLE
Enabled Bluetooth HFP Offload for Steam Deck OLED

### DIFF
--- a/kernel-patches/6.6/others/steam-deck-oled-hfp-offload.patch
+++ b/kernel-patches/6.6/others/steam-deck-oled-hfp-offload.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/bluetooth/hci_qca.c b/drivers/bluetooth/hci_qca.c
+index 3c4bb1ded551..0bd224748146 100644
+--- a/drivers/bluetooth/hci_qca.c
++++ b/drivers/bluetooth/hci_qca.c
+@@ -1827,6 +1827,24 @@ static void hci_coredump_qca(struct hci_dev *hdev)
+ 		bt_dev_err(hdev, "%s: trigger crash failed (%d)", __func__, err);
+ }
+ 
++static int qca_get_data_path_id(struct hci_dev *hdev, __u8 *data_path_id)
++{
++	/* QCA uses 1 as non-HCI data path id for HFP */
++	*data_path_id = 1;
++	return 0;
++}
++
++static int qca_configure_hfp_offload(struct hci_dev *hdev)
++{
++	bt_dev_info(hdev, "HFP non-HCI data transport is supported");
++	hdev->get_data_path_id = qca_get_data_path_id;
++	/* Do not need to send HCI_Configure_Data_Path to configure non-HCI
++	 * data transport path for QCA controllers, so set below field as NULL.
++	 */
++	hdev->get_codec_config_data = NULL;
++	return 0;
++}
++
+ static int qca_setup(struct hci_uart *hu)
+ {
+ 	struct hci_dev *hdev = hu->hdev;
+@@ -1988,6 +2006,10 @@ static int qca_setup(struct hci_uart *hu)
+ 		hu->hdev->set_bdaddr = qca_set_bdaddr_rome;
+ 	else
+ 		hu->hdev->set_bdaddr = qca_set_bdaddr;
++
++	if (soc_type == QCA_QCA2066)
++		qca_configure_hfp_offload(hdev);
++
+ 	qca->fw_version = le16_to_cpu(ver.patch_ver);
+ 	qca->controller_id = le16_to_cpu(ver.rom_ver);
+ 	hci_devcd_register(hdev, hci_coredump_qca, qca_dmp_hdr, NULL);


### PR DESCRIPTION
Offload Hands Free Profile from bluetooth audio to Steam Deck Hardware.