### PR TITLE
Added dell ASPM workarounds

### DIFF
--- a/kernel-patches/6.6/others/dell-aspm-workaround.patch
+++ b/kernel-patches/6.6/others/dell-aspm-workaround.patch
@@ -1,0 +1,121 @@
+	diff --git a/drivers/net/ethernet/realtek/r8169_main.c b/drivers/net/ethernet/realtek/r8169_main.c
+	index 57afcb2a7e00..71d5ea2929e1 100644
+	--- a/drivers/net/ethernet/realtek/r8169_main.c
+	+++ b/drivers/net/ethernet/realtek/r8169_main.c
+	@@ -15,6 +15,7 @@
+	#include <linux/etherdevice.h>
+	#include <linux/clk.h>
+	#include <linux/delay.h>
+	+#include <linux/dmi.h>
+	#include <linux/ethtool.h>
+	#include <linux/phy.h>
+	#include <linux/if_vlan.h>
+	@@ -5248,11 +5249,87 @@ static void rtl_init_mac_address(struct rtl8169_private *tp)
+		rtl_rar_set(tp, mac_addr);
+	}
+	
+	+static bool rtl_aspm_dell_workaround(struct rtl8169_private *tp)
+	+{
+	+	static const struct dmi_system_id sysids[] = {
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Vostro 16 5640"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0CA0"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Vostro 14 3440"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0CA5"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Vostro 14 3440"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0CA6"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3450"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0C99"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3450"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0C97"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3550"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0C9A"),
+	+			},
+	+		},
+	+		{
+	+			.ident = "Dell",
+	+			.matches = {
+	+				DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+	+				DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3550"),
+	+				DMI_MATCH(DMI_PRODUCT_SKU, "0C98"),
+	+			},
+	+		},
+	+		{}
+	+	};
+	+
+	+	if (tp->mac_version == RTL_GIGA_MAC_VER_46 && dmi_check_system(sysids))
+	+		return true;
+	+
+	+	return false;
+	+}
+	+
+	/* register is set if system vendor successfully tested ASPM 1.2 */
+	static bool rtl_aspm_is_safe(struct rtl8169_private *tp)
+	{
+	+	 /* definition of 0xc0b2,
+	+	  * 0: L1
+	+	  * 1: ASPM L1.0
+	+	  * 2: ASPM L0s
+	+	  * 3: CLKEREQ
+	+	  * 4-7: Reserved
+	+	  */
+		if (tp->mac_version >= RTL_GIGA_MAC_VER_61 &&
+	-	    r8168_mac_ocp_read(tp, 0xc0b2) & 0xf)
+	+		r8168_mac_ocp_read(tp, 0xc0b2) & 0xf ||
+	+		rtl_aspm_dell_workaround(tp))
+			return true;
+	
+		return false;
+	diff --git a/drivers/net/ethernet/realtek/r8169_main.c b/drivers/net/ethernet/realtek/r8169_main.c
+	index 71d5ea2929e1..94df408aa41a 100644
+	--- a/drivers/net/ethernet/realtek/r8169_main.c
+	+++ b/drivers/net/ethernet/realtek/r8169_main.c
+	@@ -5327,11 +5327,11 @@ static bool rtl_aspm_is_safe(struct rtl8169_private *tp)
+		* 3: CLKEREQ
+		* 4-7: Reserved
+		*/
+	-	if (tp->mac_version >= RTL_GIGA_MAC_VER_61 &&
+	-		r8168_mac_ocp_read(tp, 0xc0b2) & 0xf ||
+	-		rtl_aspm_dell_workaround(tp))
+	+	if ((tp->mac_version >= RTL_GIGA_MAC_VER_61 &&
+	+		(r8168_mac_ocp_read(tp, 0xc0b2) & 0x0F)) ||
+	+		rtl_aspm_dell_workaround(tp)) {
+			return true;
+	-
+	+	}
+		return false;
+	}
+	


### PR DESCRIPTION
Some non-Dell platforms equipped with r8168h/r8111 have issue on ASPM, It's very hard to fix all known issues in a short time and r8168h/r8111 is not a brand new NIC chip,
so introduce the quirk for Dell platfroms.
It's also easier to track the Dell platform and ask Realtek's effort.