### PR TITLE
Change to %s __func__ for kernel version 6.12

### DIFF
--- a/kernel-patches/6.12/others/enforce-framebuffer-matching.patch
+++ b/kernel-patches/6.12/others/enforce-framebuffer-matching.patch
@@ -1,0 +1,18 @@
+diff --git a/drivers/gpu/drm/i915/display/intel_fbdev.c b/drivers/gpu/drm/i915/display/intel_fbdev.c
+index 49a1ac4f5491..c8c10a6104c4 100644
+--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
++++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
+@@ -199,10 +199,10 @@ static int intelfb_create(struct drm_fb_helper *helper,
+ 	ifbdev->fb = NULL;
+ 
+ 	if (fb &&
+-	    (sizes->fb_width > fb->base.width ||
+-	     sizes->fb_height > fb->base.height)) {
++	    (sizes->fb_width != fb->base.width ||
++	     sizes->fb_height != fb->base.height)) {
+ 		drm_dbg_kms(&dev_priv->drm,
+-			    "BIOS fb too small (%dx%d), we require (%dx%d),"
++			    "BIOS fb not valid (%dx%d), we require (%dx%d),"
+ 			    " releasing it\n",
+ 			    fb->base.width, fb->base.height,
+ 			    sizes->fb_width, sizes->fb_height);

--- a/kernel-patches/6.12/others/panel_orientation.patch
+++ b/kernel-patches/6.12/others/panel_orientation.patch
@@ -83,14 +83,14 @@ index 5b2506c65e95..d88ebdca1766 100644
  	const char *bios_date;
  	int i;
  
-+	pr_info("drm_get_panel_orientation_quirk called with width=%d height=%d", width, height);
++	pr_info("%s called with width=%d height=%d", __func__, width, height);
 +
  	for (match = dmi_first_match(orientation_data);
  	     match;
  	     match = dmi_first_match(match + 1)) {
  		data = match->driver_data;
  
-+		pr_info("drm_get_panel_orientation_quirk dmi match found");
++		pr_info("%s dmi match found", __func__);
 +
  		if (data->width != width ||
  		    data->height != height)
@@ -101,7 +101,7 @@ index 5b2506c65e95..d88ebdca1766 100644
  		i = match_string(data->bios_dates, -1, bios_date);
 -		if (i >= 0)
 +		if (i >= 0) {
-+			pr_info("drm_get_panel_orientation_quirk dmi match applied");
++			pr_info("%s dmi match applied, __func__");
  			return data->orientation;
 +		}
  	}


### PR DESCRIPTION
And add strict framebuffer dimensions enforcement to fix issues on 4K panels.