### PR TITLE
Let upstart handle the iptsd respawns on ithc driver crashes

### DIFF
--- a/brunch-patches/99-ipts.sh
+++ b/brunch-patches/99-ipts.sh
@@ -16,27 +16,18 @@ if [ "$ithc_touchscreen" -eq 1 ]; then
 	echo "brunch: $0 ithc enabled" > /dev/kmsg
 	cat >/roota/etc/init/ithc.conf <<ITHC
 start on stopped udev-trigger
+stop on shutdown
+respawn
+oom score never
 script
-	insmod /lib/modules/$(cat /proc/version |  cut -d' ' -f3)/ithc.ko
-	sleep 2
-	iptsd \$(iptsd-find-hidraw)
+    if ! lsmod | grep -q '^ithc'; then
+        insmod /lib/modules/$(cat /proc/version |  cut -d' ' -f3)/ithc.ko 2>/dev/null || true
+        sleep 2
+    fi
+
+    exec iptsd \$(iptsd-find-hidraw)
 end script
 ITHC
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 0))); fi
-	cat >/roota/etc/init/ithc-resume.conf <<ITHCRESUMEFIX
-start on stopped udev-trigger
-script
-	dbus-monitor --system --profile "interface='org.chromium.PowerManager',member='SuspendDone'" | while read -r line; do
-		pkill -x iptsd || true
-		if lsmod | grep -q '^ithc'; then
-			rmmod ithc 2>/dev/null || true
-			insmod /lib/modules/$(cat /proc/version |  cut -d' ' -f3)/ithc.ko
-		fi
-		sleep 2
-		iptsd \$(iptsd-find-hidraw)
-	done
-end script
-ITHCRESUMEFIX
 	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 1))); fi
 	tar zxf /rootc/packages/ipts.tar.gz -C /roota
 	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 2))); fi

--- a/brunch-patches/99-ipts.sh
+++ b/brunch-patches/99-ipts.sh
@@ -28,9 +28,9 @@ script
     exec iptsd \$(iptsd-find-hidraw)
 end script
 ITHC
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 1))); fi
+	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 0))); fi
 	tar zxf /rootc/packages/ipts.tar.gz -C /roota
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 2))); fi
+	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 1))); fi
 elif [ "$ipts_touchscreen" -eq 1 ]; then
 	echo "brunch: $0 ipts enabled" > /dev/kmsg
 	cat >/roota/etc/init/ipts.conf <<IPTS
@@ -41,7 +41,7 @@ script
 	iptsd \$(iptsd-find-hidraw)
 end script
 IPTS
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 3))); fi
+	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 2))); fi
 	cat >/roota/etc/init/ipts-resume.conf <<ITPSRESUMEFIX
 start on stopped udev-trigger
 script
@@ -56,9 +56,9 @@ script
 	done
 end script
 ITPSRESUMEFIX
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 4))); fi
+	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 3))); fi
 	tar zxf /rootc/packages/ipts.tar.gz -C /roota
-	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 5))); fi
+	if [ ! "$?" -eq 0 ]; then ret=$((ret + (2 ** 4))); fi
 fi
 
 exit $ret

--- a/scripts/brunch-setup
+++ b/scripts/brunch-setup
@@ -222,7 +222,7 @@ reset
 
 fi
 
-available_cmdline_params="enforce_hyperthreading=1;snd-intel-dspcfg.dsp_driver=1;snd-intel-dspcfg.dsp_driver=4;i915.enable_fbc=0 i915.enable_psr=0;psmouse.elantech_smbus=0;psmouse.synaptics_intertouch=0"
+available_cmdline_params="enforce_hyperthreading=1;snd-intel-dspcfg.dsp_driver=1;snd-intel-dspcfg.dsp_driver=4;i915.enable_fbc=0 i915.enable_psr=0;psmouse.elantech_smbus=0;psmouse.synaptics_intertouch=0;intremap=nosid"
 echo "Select your kernel commandline parameters (press SPACE to select an item and ENTER to validate your choice)"
 multiselect "$available_cmdline_params" " "
 selected_cmdline_params="$returned_values"


### PR DESCRIPTION
The current upstart config introduces a race condition with the kernel due to `ithc` having its own suspend/resume handler which simply reinitializes itself. This resulted to the "fix" not working sometimes without any clear patterns. 

The reinitialization of the `ithc` driver results to `iptsd` crashing due to the daemon losing the hid. There should be no need to externally reinitialize it with `rmmod` and `insmod`. Simply restarting `iptsd` should work reliably. I don't know if this applies to `ipts` as well as I have no device to test this with.

Here's a sample log of the kernel driver handling sleep/suspend and resume with the `iptsd` crashing at the end (but respawned by upstart) due to reinitialization of hid:
```
[ 7915.247699] ithc 0000:00:10.6: PM: calling pci_pm_suspend @ 12297, parent: pci0000:00
[ 7915.251269] ithc 0000:00:10.6: PM: pci_pm_suspend returned 0 after 3561 usecs
[ 7915.274694] ithc 0000:00:10.6: PM: calling pci_pm_suspend_late @ 24695, parent: pci0000:00
[ 7915.274702] ithc 0000:00:10.6: PM: pci_pm_suspend_late returned 0 after 0 usecs
[ 7915.316002] ithc 0000:00:10.6: PM: calling pci_pm_suspend_noirq @ 24694, parent: pci0000:00
[ 7915.331410] ithc 0000:00:10.6: PM: pci_pm_suspend_noirq returned 0 after 15402 usecs
[ 7918.929143] ithc 0000:00:10.6: PM: calling pci_pm_resume_noirq @ 24694, parent: pci0000:00
[ 7918.945148] ithc 0000:00:10.6: PM: pci_pm_resume_noirq returned 0 after 15999 usecs
[ 7918.972481] ithc 0000:00:10.6: PM: calling pci_pm_resume_early @ 24742, parent: pci0000:00
[ 7918.972483] ithc 0000:00:10.6: PM: pci_pm_resume_early returned 0 after 0 usecs
[ 7918.980629] ithc 0000:00:10.6: PM: calling pci_pm_resume @ 24741, parent: pci0000:00
[ 7918.982496] ithc 0000:00:10.6: no ACPI config, using legacy mode
[ 7919.097059] ithc 0000:00:10.6: config: e0000402 00000000 000a00ff 0000001c 0000001c 43495424 fda00a2e 0c1a045e 00000001 05008d8b 00000000 00000000 00000000 0404035e 000001c0 00000002
[ 7919.101012] ithc 0000:00:10.6: PM: pci_pm_resume returned 0 after 120379 usecs
[ 7919.264839] hid-generic 0001:045E:0C1A.0008: input,hidraw0: <UNKNOWN> HID v1.00 Device [Intel Touch Host Controller] on pci-0000:00:10.6/ithc
[ 7924.188131] init: ithc main process (12613) terminated with status 1
[ 7924.188157] init: ithc main process ended, respawning
```

Letting upstart handle `iptsd` with respawn should ensure it's always running even after a crash due to sleep/suspend.

Also, [some devices](https://github.com/quo/ithc-linux/issues/5) require `intremap=nosid` as a kernel parameter for `ithc` to start correctly so having it as an option instead of having to type it in manually would be great.

I've tested this on my Surface Pro 7+ and it has been more reliable than the current solution.