### PR TITLE
haveged: 1.9.18 -> 1.9.19

### DIFF
--- a/scripts/build-init
+++ b/scripts/build-init
@@ -139,8 +139,8 @@ rm -rf ./fbv || { echo "Failed to make fbv"; exit 1; }
 
 git clone --depth=1 -b v1.9.19 https://github.com/jirka-h/haveged.git || { echo "Failed to make haveged"; exit 1; }
 cd haveged || { echo "Failed to make haveged"; exit 1; }
-autoreconf -i || { echo "Failed to make haveged"; exit 1; }
-./configure --prefix=/usr --libdir=/usr/lib64 --disable-init --enable-tune=no || { echo "Failed to make haveged"; exit 1; }
+autoreconf -fi || { echo "Failed to make haveged"; exit 1; }
+./configure --prefix=/usr --libdir=/usr/lib64 --enable-tune=no || { echo "Failed to make haveged"; exit 1; }
 make -j"$NTHREADS" || { echo "Failed to make haveged"; exit 1; }
 make DESTDIR=/home/chronos/haveged-pkg install || { echo "Failed to make haveged"; exit 1; }
 cp ../haveged-pkg/usr/sbin/haveged ../initramfs/sbin/ || { echo "Failed to make haveged"; exit 1; }

--- a/scripts/build-init
+++ b/scripts/build-init
@@ -137,7 +137,7 @@ for i in $(ldd ./fbv | cut -d' ' -f3); do cp "$i" ../initramfs/lib64/ || { echo 
 cd .. || { echo "Failed to make fbv"; exit 1; }
 rm -rf ./fbv || { echo "Failed to make fbv"; exit 1; }
 
-git clone --depth=1 -b v1.9.18 https://github.com/jirka-h/haveged.git || { echo "Failed to make haveged"; exit 1; }
+git clone --depth=1 -b v1.9.19 https://github.com/jirka-h/haveged.git || { echo "Failed to make haveged"; exit 1; }
 cd haveged || { echo "Failed to make haveged"; exit 1; }
 autoreconf -i || { echo "Failed to make haveged"; exit 1; }
 ./configure --prefix=/usr --libdir=/usr/lib64 --disable-init --enable-tune=no || { echo "Failed to make haveged"; exit 1; }


### PR DESCRIPTION
This pull request updates the build process for the `haveged` utility in the `scripts/build-init` script. The most important change is upgrading the `haveged` version and adjusting the build configuration steps to align with the new version.

**Haveged build process updates:**

* Upgraded the `haveged` git clone from version `v1.9.18` to `v1.9.19`, ensuring the build uses the latest stable release.
* Changed the `autoreconf` command to use the `-fi` flags, which forces reinitialization and installs missing files, improving build reliability.
* Removed the `--disable-init` flag from the `./configure` command, potentially enabling default init support in the build.