### PR TITLE
Add framebuffer enforcement to experimental kernel

### DIFF
--- a/kernel-patches/experimental-6.18/others/enforce-framebuffer-matching.patch
+++ b/kernel-patches/experimental-6.18/others/enforce-framebuffer-matching.patch
@@ -1,0 +1,18 @@
+diff --git a/drivers/gpu/drm/i915/display/intel_fbdev.c b/drivers/gpu/drm/i915/display/intel_fbdev.c
+index a42b0943ed95f..3b2676af5526c 100644
+--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
++++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
+@@ -253,10 +253,10 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
+ 	ifbdev->fb = NULL;
+ 
+ 	if (fb &&
+-	    (sizes->fb_width > fb->base.width ||
+-	     sizes->fb_height > fb->base.height)) {
++	    (sizes->fb_width != fb->base.width ||
++	     sizes->fb_height != fb->base.height)) {
+ 		drm_dbg_kms(display->drm,
+-			    "BIOS fb too small (%dx%d), we require (%dx%d),"
++			    "BIOS fb not valid (%dx%d), we require (%dx%d),"
+ 			    " releasing it\n",
+ 			    fb->base.width, fb->base.height,
+ 			    sizes->fb_width, sizes->fb_height);


### PR DESCRIPTION
This pull request makes a targeted change to the framebuffer validation logic in the Intel DRM driver. The key update enforces that the BIOS-provided framebuffer must exactly match the required width and height, rather than just being large enough. This ensures stricter compatibility between the BIOS framebuffer and what the driver expects.

Framebuffer validation update:

* Updated `intel_fbdev_driver_fbdev_probe` in `intel_fbdev.c` to require the BIOS framebuffer's width and height to exactly match the required sizes, instead of only checking for minimum dimensions. The log message was also updated to reflect this stricter validation.