### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           yes | DEBIAN_FRONTEND=noninteractive sudo apt install gcc-12 g++-12 git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison sbsigntool
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
       - name: Checkout Brunch source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Download kernels and apply patches
         run: ./prepare_kernels.sh
       - name: Define kernels matrix
@@ -52,9 +52,9 @@ jobs:
           yes | DEBIAN_FRONTEND=noninteractive sudo apt install gcc-12 g++-12 git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison sbsigntool
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
       - name: Checkout Brunch source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Download kernels source
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: kernels-source
           path: /tmp
@@ -108,9 +108,9 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo apt clean
       - name: Checkout Brunch source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Download built kernels
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: /tmp
       - name: Copy built kernels
@@ -145,7 +145,7 @@ jobs:
           echo "Free space:"
           df -h
       - name: Download built artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: brunch-build
       - name: Identify custom version

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           close-issue-message: "Unfortunately, this issue could not be resolved and is closed due to inactivity."
           close-pr-message: 'Unfortunately, this PR was not merged and is closed due to inactivity.'


### PR DESCRIPTION
This pull request updates several GitHub Actions used in workflow files to ensure compatibility with the latest versions and to benefit from recent improvements and bug fixes. The changes focus on upgrading the versions of actions used for source code checkout, artifact download, and stale issue management.

**Workflow action version upgrades:**

* Upgraded `actions/checkout` from version `v6` to `v7` in multiple steps within `.github/workflows/build.yml` to use the latest features and fixes.

* Upgraded `actions/download-artifact` from version `v7` to `v8` in `.github/workflows/build.yml` for improved artifact handling.

* Upgraded `actions/stale` from version `v10` to `v11` in `.github/workflows/issues.yml` to leverage the latest updates for managing stale issues and pull requests.